### PR TITLE
Makefile: Fix OPT_FLAGS variable assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -684,7 +684,7 @@ OPT_FLAGS := -mllvm -polly \
 		-mllvm -polly-vectorizer=stripmine \
 		-mllvm -polly-invariant-load-hoisting
 endif
-OPT_FLAGS := -mcpu=cortex-a53 -mtune=cortex-a53 \
+OPT_FLAGS += -mcpu=cortex-a53 -mtune=cortex-a53 \
 	     -march=armv8-a+crc+crypto
 else
 OPT_FLAGS := -mcpu=cortex-a73.cortex-a53 \


### PR DESCRIPTION
Currently LLVM's Polly optimizer flags are assigned to OPT_FLAGS first but after that CPU specific optimizations are assigned to it, so the CPU specific optimization flags overwrites the Polly optimization flags before getting called by the Compiler/Assembler flags.

Fix this by making the CPU specific optimization an Append Assignment flag instead of Immediate Set assignment